### PR TITLE
Systemd unit

### DIFF
--- a/default/EthControl
+++ b/default/EthControl
@@ -1,0 +1,3 @@
+ENABLED=1
+DAEMON=/usr/local/bin/EthControl
+DAEMON_OPTS="-accessToken ACCESS_TOKEN"

--- a/systemd/EthControl.service
+++ b/systemd/EthControl.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=EthControl mining service
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/EthControl
+ExecStart=/usr/local/bin/EthControl $DAEMON_OPTS
+KillMode=process
+User=miner
+Group=miner
+WorkingDirectory=~
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I've quickly written a systemd unit file in order to run EthControl as a service.
Basically, you put systemd/EthControl.service in the `/etc/systemd/system` folder and default/EthControl in the `/etc/default` folder.
Then, you will have to adjust both of the file to your local installation :
 * For systemd/EthControl.service : path to EthControl binary, user/group/directory in which you wish to run it
 * For default/EthControl : Your access token
Note that if you want to run EthControl as a non-privileged user (i.e. not root), you may have to `chmod +s` (e.g. fan speed for Claymore)